### PR TITLE
Turn off CodeCov comments in PRs

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,4 @@
+src_dir: src
+coverage_clover: tests/clover.xml
+json_path: tests/coveralls.json
+service_name: travis-ci

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-src_dir: src
-coverage_clover: tests/clover.xml
-json_path: tests/coveralls.json
-service_name: travis-ci

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This wrapper utilizes the [Requests](https://github.com/rmccue/requests) library
 
 Once included in your project, setup should be very straightforward.  Only requirement is a valid API key provided by [NewsAPI.org](NewsAPI.org/account/).
 
-
 ## Usage
 
 ### Step 1. Set Access Token 
@@ -44,10 +43,9 @@ Making requests to the API is done via `query` method, which accepts three param
 
 **`Query` parameters:**
 
-* `(string) $endpoint` Target endpoint. Options are `top`, `everything`, and `sources`.
-* `(array) $query_params` Query parameters passed to NewsAPI.org
-* `(array) $request_options` Options passed to Requests library to control CURL.
-
+  * `(string) $endpoint` Target endpoint. Options are `top`, `everything`, and `sources`.
+  * `(array) $query_params` Query parameters passed to NewsAPI.org
+  * `(array) $request_options` Options passed to Requests library to control CURL.
 
 **Examples:** 
 
@@ -81,8 +79,6 @@ $request->url                     // string(54) "https://newsapi.org/v2/top-head
 $request->body                    // string(14385) "{...}"
 ```
 
-
 ## Change log
 
 > [Automated release notes can be found here →](https://github.com/gfargo/newsapi/releases)
-

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Making requests to the API is done via `query` method, which accepts three param
 
 **`Query` parameters:**
 
-  * `(string) $endpoint` Target endpoint. Options are `top`, `everything`, and `sources`.
-  * `(array) $query_params` Query parameters passed to NewsAPI.org
-  * `(array) $request_options` Options passed to Requests library to control CURL.
+* `(string) $endpoint` Target endpoint. Options are `top`, `everything`, and `sources`.
+* `(array) $query_params` Query parameters passed to NewsAPI.org
+* `(array) $request_options` Options passed to Requests library to control CURL.
 
 **Examples:** 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newsapi",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "PHP API wrapper for NewsAPI.org. NPM automates Github releases.",
   "scripts": {
     "release": "release-it"
@@ -18,5 +18,10 @@
   "homepage": "https://github.com/gfargo/newsapi#readme",
   "devDependencies": {
     "release-it": "^7.4.7"
+  },
+  "release-it": {
+    "github": {
+      "release": true
+    }
   }
 }


### PR DESCRIPTION
[Per docs](https://docs.codecov.io/docs/codecov-yaml), disabling CodeCoverage bot comments can be done through the root config file. 