### PR TITLE
Implement PHP CodeSniffer within Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
 script:
   - phpunit --coverage-clover=coverage.xml
-  - phpcs -s
+  - phpcs -s src
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 
   # Environment checks
   - phpunit --version
-  - phpcs --version
+  - vendor/bin/phpcs --version
 
   # Install & update Snyk.io vulnerability testing
   - npm install -g snyk
@@ -34,7 +34,7 @@ install:
 
 script:
   - phpunit --coverage-clover=coverage.xml
-  - phpcs -s src
+  - vendor/bin/phpcs -s src
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 
   # Environment checks
   - phpunit --version
+  - phpcs --version
 
   # Install & update Snyk.io vulnerability testing
   - npm install -g snyk
@@ -33,6 +34,7 @@ install:
 
 script:
   - phpunit --coverage-clover=coverage.xml
+  - phpcs -s
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "rmccue/requests": "^1.7"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.5"
+    "phpunit/phpunit": "7.5",
+    "squizlabs/php_codesniffer": "3.*"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53690ad54f074ac48cdce42b871d3d3f",
+    "content-hash": "2bbd48a943a7d1b12ddb4c54b061da23",
     "packages": [
         {
             "name": "rmccue/requests",
@@ -1376,6 +1376,57 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/379deb987e26c7cd103a7b387aea178baec96e48",
+                "reference": "379deb987e26c7cd103a7b387aea178baec96e48",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-12-19T23:57:18+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.10.0",
             "source": {
@@ -1530,6 +1581,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=7.1"
+    },
     "platform-dev": []
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,7 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="newsapi" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>The coding standard for PHP NewsAPI wrapper.</description>
 
-    <file>lib</file>
+    <file>src</file>
     <file>tests</file>
 
     <exclude-pattern>*/Standards/*/Tests/*\.(inc|css|js)</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,33 +8,58 @@
     <exclude-pattern>*/Standards/*/Tests/*\.(inc|css|js)</exclude-pattern>
 
     <arg name="basepath" value="."/>
+    <arg name="tab-width" value="4"/>
     <arg name="colors"/>
     <arg name="parallel" value="75"/>
     <arg value="np"/>
+
 
     <!-- Don't hide tokenizer exceptions -->
     <rule ref="Internal.Tokenizer.Exception">
         <type>error</type>
     </rule>
 
-    <!-- Include the whole PEAR standard -->
+    <!-- PEAR standard -->
     <rule ref="PEAR">
         <exclude name="PEAR.NamingConventions.ValidFunctionName"/>
         <exclude name="PEAR.NamingConventions.ValidVariableName"/>
         <exclude name="PEAR.Commenting.ClassComment"/>
         <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
+        <exclude name="PEAR.Commenting.FileComment.MissingLicenseTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingPackageTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingLinkTag"/>
         <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
         <exclude name="PEAR.Commenting.InlineComment"/>
+        <exclude name="PEAR.Classes.ClassDeclaration.OpenBraceNewLine"/>
+        <exclude name="PEAR.Functions.FunctionDeclaration.BraceOnSameLine"/>
+        <exclude name="PEAR.Functions.FunctionDeclaration.BraceOnSameLine"/>
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
+        <exclude name="PEAR.ControlStructures.MultiLineCondition.SpacingAfterOpenBrace"/>
+    </rule>
+    <!-- Only one argument per line in multi-line function calls -->
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="allowMultipleArguments" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="PEAR.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="tabIndent" value="true" />
+        </properties>
     </rule>
 
-    <!-- Include some sniffs from other standards that don't conflict with PEAR -->
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
-    <rule ref="Squiz.Arrays.ArrayDeclaration"/>
-    <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
+    <!-- PSR2 Standard -->
+    <rule ref="PSR2.Classes.PropertyDeclaration"/>
+    <rule ref="PSR2.Methods.MethodDeclaration"/>
+    <rule ref="PSR2.Files.EndFileNewline"/>
+
+    <!-- Squiz Standard -->
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
+    <rule ref="Squiz.Scope.MethodScope"/>
     <rule ref="Squiz.Commenting.BlockComment"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
     <rule ref="Squiz.Commenting.EmptyCatchComment"/>
@@ -42,17 +67,18 @@
     <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
     <rule ref="Squiz.Commenting.PostStatementComment"/>
     <rule ref="Squiz.Commenting.VariableComment"/>
+    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
+
     <rule ref="Squiz.Formatting.OperatorBracket"/>
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
-    <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
-    <rule ref="Squiz.PHP.DisallowInlineIf"/>
-    <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
-    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
-    <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace"/>
-    <rule ref="Squiz.WhiteSpace.FunctionSpacing"/>
     <rule ref="Squiz.WhiteSpace.OperatorSpacing"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="true"/>
+        </properties>
+    </rule>
+
+
+    <!-- Generic Rules -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Commenting.Todo"/>
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>
@@ -62,54 +88,11 @@
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
     <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
-    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
-    <rule ref="PSR2.Classes.PropertyDeclaration"/>
-    <rule ref="PSR2.Methods.MethodDeclaration"/>
-    <rule ref="PSR2.Files.EndFileNewline"/>
-    <rule ref="Zend.Files.ClosingTag"/>
-
-    <!-- PEAR uses warnings for inline control structures, so switch back to errors -->
-    <rule ref="Generic.ControlStructures.InlineControlStructure">
-        <properties>
-            <property name="error" value="true"/>
-        </properties>
+    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent">
+        <exclude name="Generic.WhiteSpace.DisallowTabIndent" />
     </rule>
 
-    <!-- We use custom indent rules for arrays -->
-    <rule ref="Generic.Arrays.ArrayIndent"/>
-    <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNotAligned">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned">
-        <severity>0</severity>
-    </rule>
-    <rule ref="Squiz.Arrays.ArrayDeclaration.CloseBraceNewLine">
-        <severity>0</severity>
-    </rule>
-
-    <!-- Check var names, but we don't want leading underscores for private vars -->
-    <rule ref="Squiz.NamingConventions.ValidVariableName"/>
-    <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
-        <severity>0</severity>
-    </rule>
-
-    <!-- Only one argument per line in multi-line function calls -->
-    <rule ref="PEAR.Functions.FunctionCallSignature">
-        <properties>
-            <property name="allowMultipleArguments" value="false"/>
-        </properties>
-    </rule>
-
-    <!-- Have 12 chars padding maximum and always show as errors -->
-    <rule ref="Generic.Formatting.MultipleStatementAlignment">
-        <properties>
-            <property name="maxPadding" value="12"/>
-            <property name="error" value="true"/>
-        </properties>
-    </rule>
 
     <!-- Ban some functions -->
     <rule ref="Generic.PHP.ForbiddenFunctions">
@@ -124,18 +107,27 @@
         </properties>
     </rule>
 
-    <!-- Private methods MUST not be prefixed with an underscore -->
-    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
-        <type>error</type>
-    </rule>
-
-    <!-- Private properties MUST not be prefixed with an underscore -->
-    <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
-        <type>error</type>
-    </rule>
-
     <!-- The testing bootstrap file uses string concats to stop IDEs seeing the class aliases -->
     <rule ref="Generic.Strings.UnnecessaryStringConcat">
         <exclude-pattern>tests/bootstrap.php</exclude-pattern>
     </rule>
+
+    <!-- PEAR uses warnings for inline control structures, so switch back to errors -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure">
+        <properties>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- We use custom indent rules for arrays -->
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+
+    <!-- Have 12 chars padding maximum and always show as errors -->
+    <rule ref="Generic.Formatting.MultipleStatementAlignment">
+        <properties>
+            <property name="maxPadding" value="12"/>
+            <property name="error" value="true"/>
+        </properties>
+    </rule>
+
 </ruleset>

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 /**
  * NewsAPI Static Proxy Class Client
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 
@@ -42,9 +42,10 @@ final class Client {
 
 	/**
 	 * Check if API access token is valid.
+	 *
 	 * @return bool
 	 */
-	public static function isAccessTokenValid() {
+	public static function isAccessTokenValid(): bool {
 		return ! empty( self::$api_token ) && is_string( self::$api_token );
 	}
 
@@ -81,7 +82,7 @@ final class Client {
 	 *
 	 * @return \Requests_Response Response object from from API request.
 	 */
-	public static function query( string $endpoint, array $query_params = [], array $request_options = [] ) {
+	public static function query( string $endpoint, array $query_params = [], array $request_options = [] ): \Requests_Response {
 		return self::getAdapter()->query( $endpoint, $query_params, $request_options );
 	}
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0*
  */
 
 namespace NewsAPI;

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,8 +2,8 @@
 /**
  * NewsAPI Static Proxy Class Client
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI;
@@ -14,30 +14,30 @@ final class Client {
 	 *
 	 * @var string
 	 */
-	public static $api_version = 'V2';
+	public static $version = 'V2';
 
 	/**
 	 * API access token used in requests.
 	 *
 	 * @var string
 	 */
-	protected static $api_token;
+	protected static $privateKey;
 
 	/**
 	 * This is a static class, do not instantiate it
-	 *
-	 * @codeCoverageIgnore
 	 */
 	private function __construct() {
 	}
 
 	/**
-	 * Register personal API access token.
+	 * Register API access token.
 	 *
-	 * @param string $api_token
+	 * @param string $apiKey Personal API access key
+	 *
+	 * @return void
 	 */
-	public static function setAccessToken( string $api_token ) {
-		self::$api_token = $api_token;
+	public static function setAccessToken( string $apiKey ) {
+		self::$privateKey = $apiKey;
 	}
 
 	/**
@@ -46,13 +46,14 @@ final class Client {
 	 * @return bool
 	 */
 	public static function isAccessTokenValid(): bool {
-		return ! empty( self::$api_token ) && is_string( self::$api_token );
+		return ! empty( self::$privateKey ) && is_string( self::$privateKey );
 	}
 
 	/**
 	 * Returns Instance of API Adapter.
 	 *
 	 * @return RemoteAPI
+	 *
 	 * @throws \Exception
 	 */
 	public static function getAdapter(): RemoteAPI {
@@ -61,28 +62,28 @@ final class Client {
 			throw new \Exception( 'The API access token hasn\'t been set properly. Register your API access token via the `set_access_token` method. If you do not have an access token, one can be created at https://newsapi.org/account', 1 );
 		}
 
-		static $adapter = null;
+		static $adapterObj = null;
 
-		if ( null === $adapter ) {
-			$adapter_version = __NAMESPACE__ . '\\' . self::$api_version . '\\Adapter';
-			$adapter         = new $adapter_version( self::$api_token );
+		if ( null === $adapterObj ) {
+			$adapter    = __NAMESPACE__ . '\\' . self::$version . '\\Adapter';
+			$adapterObj = new $adapter( self::$privateKey );
 		}
 
-		return $adapter;
+		return $adapterObj;
 	}
 
 	/**
 	 * Query API using selected Adapter.
 	 *
-	 * @param string $endpoint
-	 * @param array  $query_params
-	 * @param array  $request_options
+	 * @param string $endpoint       Slug of target API endpoint.  Options are 'top', 'everything', and 'sources'.
+	 * @param array  $queryParams    Query parameters passed to NewsAPI.org
+	 * @param array  $requestOptions Args passed to Requests library to control CURL.
 	 *
 	 * @throws \Exception
 	 *
 	 * @return \Requests_Response Response object from from API request.
 	 */
-	public static function query( string $endpoint, array $query_params = [], array $request_options = [] ): \Requests_Response {
-		return self::getAdapter()->query( $endpoint, $query_params, $request_options );
+	public static function query( string $endpoint, array $queryParams = [], array $requestOptions = [] ): \Requests_Response {
+		return self::getAdapter()->query( $endpoint, $queryParams, $requestOptions );
 	}
 }

--- a/src/RemoteAPI.php
+++ b/src/RemoteAPI.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 namespace NewsAPI;

--- a/src/RemoteAPI.php
+++ b/src/RemoteAPI.php
@@ -3,7 +3,7 @@
  * Base abstract class for API adapters.
  *
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/src/RemoteAPI.php
+++ b/src/RemoteAPI.php
@@ -2,9 +2,8 @@
 /**
  * Base abstract class for API adapters.
  *
- *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI;
@@ -13,5 +12,14 @@ abstract class RemoteAPI {
 	use Traits\RemoteEndpoints;
 	use Traits\RemoteHeaders;
 
-	abstract function query( string $endpoint, array $api_params = [], array $request_options = [] ): \Requests_Response;
+	/**
+	 * Query Remote
+	 *
+	 * @param string $endpoint       Slug of target remote endpoint
+	 * @param array  $apiParams      Query parameters passed to remote API
+	 * @param array  $requestOptions Options controlling how request is made to remote
+	 *
+	 * @return \Requests_Response
+	 */
+	abstract public function query( string $endpoint, array $apiParams = [], array $requestOptions = [] ): \Requests_Response;
 }

--- a/src/traits/RemoteEndpoints.php
+++ b/src/traits/RemoteEndpoints.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 namespace NewsAPI\Traits;

--- a/src/traits/RemoteEndpoints.php
+++ b/src/traits/RemoteEndpoints.php
@@ -2,8 +2,8 @@
 /**
  * Interface for Remote API Endpoints
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI\Traits;
@@ -28,16 +28,20 @@ trait RemoteEndpoints {
 	/**
 	 * Return URL for target endpoint.
 	 *
-	 * @param $endpoint_slug
+	 * @param string $endpointSlug Key value for target URL.
 	 *
 	 * @return array|null
 	 */
-	public function getEndpointUrl( $endpoint_slug ) {
-		return isset( $this->endpoints[ $endpoint_slug ] ) ? $this->endpoints[ $endpoint_slug ] : null;
+	public function getEndpointUrl( string $endpointSlug ) {
+		return isset( $this->endpoints[ $endpointSlug ] ) ? $this->endpoints[ $endpointSlug ] : null;
 	}
 
 	/**
-	 * @param array $endpoints
+	 * Setup available remote endpoints.
+	 *
+	 * @param array $endpoints List of remote endpoints
+	 *
+	 * @return void
 	 */
 	protected function setEndpoints( array $endpoints ): void {
 		$this->endpoints = array_merge( $this->endpoints, $endpoints );

--- a/src/traits/RemoteEndpoints.php
+++ b/src/traits/RemoteEndpoints.php
@@ -2,7 +2,7 @@
 /**
  * Interface for Remote API Endpoints
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/src/traits/RemoteHeaders.php
+++ b/src/traits/RemoteHeaders.php
@@ -2,22 +2,29 @@
 /**
  * Interface for Remote API Headers
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI\Traits;
 
 trait RemoteHeaders {
 	/**
-	 * HTTP Headers used with API requests.
+	 * HTTP Headers used for remote requests.
+	 *
+	 * Each remote is stored as a key value pair, the key being the slug while
+	 * the value stored is the URL of the target endpoint.
 	 *
 	 * @var array
 	 */
 	protected $headers = [];
 
 	/**
-	 * @param array $headers
+	 * Set Request Headers.
+	 *
+	 * @param array $headers HTTP headers
+	 *
+	 * @return void
 	 */
 	public function setHeaders( $headers ): void {
 		$this->headers = array_merge( $this->headers, $headers );
@@ -26,7 +33,7 @@ trait RemoteHeaders {
 	/**
 	 * Retrieve all registered headers.
 	 *
-	 * @return array
+	 * @return array Headers used in requests to API.
 	 */
 	public function getHeaders() {
 		return $this->headers;

--- a/src/traits/RemoteHeaders.php
+++ b/src/traits/RemoteHeaders.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 namespace NewsAPI\Traits;

--- a/src/traits/RemoteHeaders.php
+++ b/src/traits/RemoteHeaders.php
@@ -2,7 +2,7 @@
 /**
  * Interface for Remote API Headers
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/src/v2/Adapter.php
+++ b/src/v2/Adapter.php
@@ -2,8 +2,8 @@
 /**
  * NewsAPI v2 Adapter Class
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI\V2;
@@ -14,21 +14,21 @@ class Adapter extends \NewsAPI\RemoteAPI {
 	 *
 	 * @var string|null
 	 */
-	private $access_token;
+	private $_privateKey;
 
 	/**
 	 * Initialize API Wrapper.
 	 *
-	 * @param string $access_token API Authorization key.
+	 * @param string $apiKey API Authorization key.
 	 *
 	 * @throws \Exception PHP Exceptions.
 	 * @since  1.0.0
 	 */
-	public function __construct( string $access_token ) {
-		$this->access_token = isset( $access_token ) ? $access_token : null;
+	public function __construct( string $apiKey ) {
+		$this->_privateKey = isset( $apiKey ) ? $apiKey : null;
 
 		// Bail if empty.
-		if ( empty( $this->access_token ) ) {
+		if ( empty( $this->_privateKey ) ) {
 			throw new \Exception( 'API key is missing, please ensure valid key is provided.  If you do not have a key one can be created at https://newsapi.org/account', 1 );
 		}
 
@@ -36,7 +36,7 @@ class Adapter extends \NewsAPI\RemoteAPI {
 			'Access-Control-Allow-Origin'      => '*',
 			'Access-Control-Allow-Methods'     => 'POST, GET',
 			'Access-Control-Allow-Credentials' => 'true',
-			'x-api-key'                        => $this->access_token,
+			'x-api-key'                        => $this->_privateKey,
 		] );
 
 		$this->setEndpoints( [
@@ -51,40 +51,40 @@ class Adapter extends \NewsAPI\RemoteAPI {
 	/**
 	 * Construct the GET request URL.
 	 *
-	 * @param string $endpoint     Target endpoint.  Options are 'top', 'everything', and 'sources'
-	 * @param array  $query_params API Request parameters.
+	 * @param string $endpoint    Target endpoint.  Options are 'top', 'everything', and 'sources'
+	 * @param array  $queryParams API Request parameters.
 	 *
 	 * @throws \Exception
 	 *
 	 * @return string
 	 */
-	public function buildRequestUrl( string $endpoint, array $query_params ) {
+	public function buildRequestUrl( string $endpoint, array $queryParams ) {
 		// Check we are working with valid endpoint.
-		$valid_endpoints = array_keys( $this->getEndpoints() );
+		$validEndpoints = array_keys( $this->getEndpoints() );
 
-		if ( empty( $endpoint ) || ! in_array( $endpoint, $valid_endpoints ) ) {
-			throw new \Exception( sprintf( 'Invalid endpoint. Valid options are "%s"', implode( '", "', $valid_endpoints ) ), 1 );
+		if ( empty( $endpoint ) || ! in_array( $endpoint, $validEndpoints ) ) {
+			throw new \Exception( sprintf( 'Invalid endpoint. Valid options are "%s"', implode( '", "', $validEndpoints ) ), 1 );
 		}
 
-		$http_query_url = http_build_query( $query_params );
+		$httpQueryUrl = http_build_query( $queryParams );
 
-		return (string) $this->getEndpointUrl( $endpoint ) . '?' . $http_query_url;
+		return (string) $this->getEndpointUrl( $endpoint ) . '?' . $httpQueryUrl;
 	}
 
 	/**
-	 * Query API for Results.
+	 * Query V2 API Endpoints for Results.
 	 *
-	 * @param string $endpoint        Slug of target API endpoint.  Options are 'top', 'everything', and 'sources'.
-	 * @param array  $query_params    Query parameters passed to NewsAPI.org
-	 * @param array  $request_options Options passed to Requests library to control CURL.
+	 * @param string $endpoint       Slug of target API endpoint.  Options are 'top', 'everything', and 'sources'.
+	 * @param array  $queryParams    Query parameters passed to NewsAPI.org
+	 * @param array  $requestOptions Options controlling how request is made to remote
 	 *
 	 * @throws \Exception
 	 *
 	 * @return \Requests_Response Response object from from API request.
 	 */
-	public function query( string $endpoint, array $query_params = [], array $request_options = [] ): \Requests_Response {
-		$request_url = $this->buildRequestUrl( $endpoint, $query_params );
-		$response    = \Requests::get( $request_url, $this->getHeaders(), $request_options );
+	public function query( string $endpoint, array $queryParams = [], array $requestOptions = [] ): \Requests_Response {
+		$requestUrl = $this->buildRequestUrl( $endpoint, $queryParams );
+		$response   = \Requests::get( $requestUrl, $this->getHeaders(), $requestOptions );
 
 		return $response;
 	}

--- a/src/v2/Adapter.php
+++ b/src/v2/Adapter.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * NewsAPI PHP Wrapper
+ * NewsAPI v2 Adapter Class
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/src/v2/Adapter.php
+++ b/src/v2/Adapter.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 namespace NewsAPI\V2;

--- a/tests/php/ClientTest.php
+++ b/tests/php/ClientTest.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 namespace NewsAPI\Tests;

--- a/tests/php/ClientTest.php
+++ b/tests/php/ClientTest.php
@@ -2,7 +2,7 @@
 /**
  * Test Client Static Proxy Class
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/tests/php/ClientTest.php
+++ b/tests/php/ClientTest.php
@@ -2,8 +2,8 @@
 /**
  * Test Client Static Proxy Class
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI\Tests;
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 class ClientTest extends TestCase {
 	/**
 	 * Test API access token.
+	 *
 	 * @var string
 	 */
 	private $test_access_token = 'test_token';
@@ -41,6 +42,7 @@ class ClientTest extends TestCase {
 
 	/**
 	 * Test that Adapter class properly extends RemoteAPI abstract class.
+	 *
 	 * @throws \Exception
 	 */
 	public function testGetAdapter_ShouldExtendRemoteAPI() {
@@ -53,6 +55,7 @@ class ClientTest extends TestCase {
 
 	/**
 	 * Test exception is thrown when using invalid API endpoint.
+	 *
 	 * @throws \Exception
 	 */
 	public function testQuery_ShouldThrowException_WhenUsingInvalidEndpoint() {

--- a/tests/php/DependencyTest.php
+++ b/tests/php/DependencyTest.php
@@ -2,7 +2,7 @@
 /**
  * Test for library dependencies.
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/tests/php/DependencyTest.php
+++ b/tests/php/DependencyTest.php
@@ -2,8 +2,8 @@
 /**
  * Test for library dependencies.
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI\Tests;

--- a/tests/php/DependencyTest.php
+++ b/tests/php/DependencyTest.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 namespace NewsAPI\Tests;

--- a/tests/php/RemoteAPITest.php
+++ b/tests/php/RemoteAPITest.php
@@ -2,8 +2,8 @@
 /**
  * Tests for RemoteAPI abstract class.
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI\Tests;

--- a/tests/php/RemoteAPITest.php
+++ b/tests/php/RemoteAPITest.php
@@ -2,7 +2,7 @@
 /**
  * Tests for RemoteAPI abstract class.
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/tests/php/RemoteAPITest.php
+++ b/tests/php/RemoteAPITest.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since 0.2.0
  */
 
 namespace NewsAPI\Tests;

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit Bootstrap File.
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -2,12 +2,12 @@
 /**
  * PHPUnit Bootstrap File.
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 // Include composer autoloader.
-include( dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php' );
+require  dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php' ;
 
 /**
  * NewsAPIMockTransport Test Class

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -4,10 +4,11 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 // Include composer autoloader.
-require  dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php' ;
+require dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php';
 
 /**
  * NewsAPIMockTransport Test Class
@@ -15,9 +16,9 @@ require  dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php' ;
  * Mock class that allows the testing of requests made by the `query` method.
  */
 class NewsAPIMockTransport implements \Requests_Transport {
-	public $code = 200;
-	public $chunked = false;
-	public $body = 'Test Body';
+	public $code        = 200;
+	public $chunked     = false;
+	public $body        = 'Test Body';
 	public $raw_headers = '';
 
 	private static $messages = [
@@ -35,8 +36,8 @@ class NewsAPIMockTransport implements \Requests_Transport {
 	];
 
 	public function request( $url, $headers = [], $data = [], $options = [] ) {
-		$status   = isset( self::$messages[ $this->code ] ) ? self::$messages[ $this->code ] : $this->code . ' unknown';
-		$response = "HTTP/1.0 $status\r\n";
+		$status    = isset( self::$messages[ $this->code ] ) ? self::$messages[ $this->code ] : $this->code . ' unknown';
+		$response  = "HTTP/1.0 $status\r\n";
 		$response .= "Content-Type: text/plain\r\n";
 		if ( $this->chunked ) {
 			$response .= "Transfer-Encoding: chunked\r\n";
@@ -51,10 +52,10 @@ class NewsAPIMockTransport implements \Requests_Transport {
 	public function request_multiple( $requests, $options ) {
 		$responses = [];
 		foreach ( $requests as $id => $request ) {
-			$handler              = new MockTransport();
-			$handler->code        = $request['options']['mock.code'];
-			$handler->chunked     = $request['options']['mock.chunked'];
-			$handler->body        = $request['options']['mock.body'];
+			$handler          = new MockTransport();
+			$handler->code    = $request['options']['mock.code'];
+			$handler->chunked = $request['options']['mock.chunked'];
+			$handler->body    = $request['options']['mock.body'];
 			$handler->raw_headers = $request['options']['mock.raw_headers'];
 			$responses[ $id ]     = $handler->request( $request['url'], $request['headers'], $request['data'], $request['options'] );
 

--- a/tests/php/v2/AdapterV2Test.php
+++ b/tests/php/v2/AdapterV2Test.php
@@ -2,7 +2,7 @@
 /**
  * Test V2 Adapter class.
  *
- * @author  gfargo
+ * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
  */
 

--- a/tests/php/v2/AdapterV2Test.php
+++ b/tests/php/v2/AdapterV2Test.php
@@ -4,6 +4,7 @@
  *
  * @package NewsAPI
  * @author  GFargo <griffen@alley.co>
+ * @since   0.2.0
  */
 
 namespace NewsAPI\Tests;
@@ -163,12 +164,14 @@ class AdapterV2Test extends TestCase {
 	}
 
 	public function testQuery_ShouldReturnRequestResponseObject() {
-		$transport = new \NewsAPIMockTransport();
+		$transport       = new \NewsAPIMockTransport();
 		$transport->code = 200;
 
-		$response = $this->adapter->query('everything', [], [
-			'transport' => $transport
-		]);
+		$response = $this->adapter->query('everything',
+			[],
+			[
+				'transport' => $transport
+			]);
 
 		$this->assertEquals(200, $response->status_code);
 		$this->assertEquals(0, $response->redirects);

--- a/tests/php/v2/AdapterV2Test.php
+++ b/tests/php/v2/AdapterV2Test.php
@@ -2,8 +2,8 @@
 /**
  * Test V2 Adapter class.
  *
- * @author  GFargo <griffen@alley.co>
  * @package NewsAPI
+ * @author  GFargo <griffen@alley.co>
  */
 
 namespace NewsAPI\Tests;
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 class AdapterV2Test extends TestCase {
 	/**
 	 * Instance of v2 Adapter class
+	 *
 	 * @var Adapter
 	 */
 	private $adapter;
@@ -115,29 +116,29 @@ class AdapterV2Test extends TestCase {
 	 */
 	public function testBuildRequestUrl_ShouldMatchExpected_WhenUsingSameParameters() {
 		// Top business headlines from Germany.
-		$expected_url  = 'https://newsapi.org/v2/top-headlines?country=de&category=business';
-		$generated_url = $this->adapter->buildRequestUrl(
+		$expected  = 'https://newsapi.org/v2/top-headlines?country=de&category=business';
+		$generated = $this->adapter->buildRequestUrl(
 			'top',
 			[
 				'country'  => 'de',
 				'category' => 'business',
 			]
 		);
-		$this->assertEquals( $expected_url, $generated_url );
+		$this->assertEquals( $expected, $generated );
 
 		// Top headlines from BBC News.
-		$expected_url  = 'https://newsapi.org/v2/top-headlines?sources=bbc-news';
-		$generated_url = $this->adapter->buildRequestUrl(
+		$expected  = 'https://newsapi.org/v2/top-headlines?sources=bbc-news';
+		$generated = $this->adapter->buildRequestUrl(
 			'top',
 			[
 				'sources' => 'bbc-news',
 			]
 		);
-		$this->assertEquals( $expected_url, $generated_url );
+		$this->assertEquals( $expected, $generated );
 
 		// All articles mentioning Apple from yesterday, sorted by popular publishers first.
-		$expected_url  = 'https://newsapi.org/v2/everything?q=apple&from=2019-01-17&to=2019-01-17&sortBy=popularity';
-		$generated_url = $this->adapter->buildRequestUrl(
+		$expected  = 'https://newsapi.org/v2/everything?q=apple&from=2019-01-17&to=2019-01-17&sortBy=popularity';
+		$generated = $this->adapter->buildRequestUrl(
 			'everything',
 			[
 				'q'      => 'apple',
@@ -146,19 +147,19 @@ class AdapterV2Test extends TestCase {
 				'sortBy' => 'popularity',
 			]
 		);
-		$this->assertEquals( $expected_url, $generated_url );
+		$this->assertEquals( $expected, $generated );
 
 		// All named sources with English news in the US.
-		$expected_url  = 'https://newsapi.org/v2/sources?language=en&country=us';
-		$generated_url = $this->adapter->buildRequestUrl(
+		$expected  = 'https://newsapi.org/v2/sources?language=en&country=us';
+		$generated = $this->adapter->buildRequestUrl(
 			'sources',
 			[
 				'language' => 'en',
 				'country'  => 'us',
 			]
 		);
-		$this->assertEquals( $expected_url, $generated_url );
-		unset( $expected_url, $generated_url );
+		$this->assertEquals( $expected, $generated );
+		unset( $expected, $generated );
 	}
 
 	public function testQuery_ShouldReturnRequestResponseObject() {


### PR DESCRIPTION
- Updates `phpcs.xml` ruleset
- Adds `@since` tag
- Resolves numerous nit-picking formatting issues discovered by phpcs
- Caves into using camelCase for all variables
... and more!